### PR TITLE
ong and campaign entities displayed in their respective components

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -17,8 +17,16 @@ const routes: Routes = [
     loadChildren: () => import('./modules/ong/ong.module').then(m => m.OngModule)
   },
   {
+    path: 'ong-form',
+    component: OngFormComponent
+  },
+  {
     path: 'campaign',
     loadChildren: () => import('./modules/campaign/campaign.module').then(m => m.CampaignModule)
+  },
+  {
+    path: 'campaign-form',
+    component: CampaignFormComponent
   },
   { path: '', redirectTo: '/inicio', pathMatch: 'full' },
   {

--- a/src/app/inicio/inicio.component.html
+++ b/src/app/inicio/inicio.component.html
@@ -1,4 +1,6 @@
 <div class="container">
   <p>WELCOME</p>
   <h4>STATUS {{response}}</h4>
+
+  <p>{{displayJSON()}}</p>
 </div>

--- a/src/app/inicio/inicio.component.ts
+++ b/src/app/inicio/inicio.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { AngularTokenService } from 'angular-token';
+import { SearchService } from '../services/search.service';
 import { SharedService } from '../services/shared.service';
 
 @Component({
@@ -10,9 +11,11 @@ import { SharedService } from '../services/shared.service';
 export class InicioComponent implements OnInit {
 
   response:any;
+  init_entities: any[] = [];
 
   constructor(public tokenService: AngularTokenService,
-              private sharedService: SharedService) { }
+              private sharedService: SharedService,
+              private searchService: SearchService) { }
 
   ngOnInit(): void {
     this.tokenService.validateToken().subscribe(
@@ -23,6 +26,19 @@ export class InicioComponent implements OnInit {
                     this.response = error['statusText']}
     )
     this.sharedService.sendReloadEvent()
-  }  
+    this.getInitEntities()
+  }
+
+  getInitEntities() {
+    this.searchService.getInitEntities().subscribe(
+      res_initEntities => {
+        this.init_entities = res_initEntities;
+      }
+    );
+  }
+
+  displayJSON() {
+    return JSON.stringify(this.init_entities, null, 4)
+  }
 
 }

--- a/src/app/modules/campaign/campaign.component.html
+++ b/src/app/modules/campaign/campaign.component.html
@@ -1,1 +1,2 @@
 <p>campaign works!</p>
+<p>{{displayCampaign()}}</p>

--- a/src/app/modules/campaign/campaign.component.ts
+++ b/src/app/modules/campaign/campaign.component.ts
@@ -1,4 +1,8 @@
 import { Component, OnInit } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { Campaign } from 'src/app/models/campaign.model';
+import { CampaignService } from 'src/app/services/campaign.service';
+import { SharedService } from 'src/app/services/shared.service';
 
 @Component({
   selector: 'app-campaign',
@@ -7,9 +11,30 @@ import { Component, OnInit } from '@angular/core';
 })
 export class CampaignComponent implements OnInit {
 
-  constructor() { }
+  campaign: Campaign;
+  reloadEventsubscription: Subscription;
+
+  constructor(private campaignService: CampaignService,
+              private sharedService: SharedService) {
+    this.reloadEventsubscription =
+      this.sharedService.getReloadEvent().subscribe(() => {
+        this.getCampaign()
+      })
+  }
 
   ngOnInit(): void {
+    this.getCampaign()
+  }
+
+  getCampaign() {
+    let obj = JSON.parse(localStorage.getItem('entitySelected') ?? "Default");
+    this.campaignService.getCampaign(obj ? obj.id.toString() : '0').subscribe(
+      res_campaign => { this.campaign = res_campaign }
+    )
+  }
+
+  displayCampaign() {
+    return JSON.stringify(this.campaign, null, 4)
   }
 
 }

--- a/src/app/modules/ong/ong.component.html
+++ b/src/app/modules/ong/ong.component.html
@@ -1,1 +1,2 @@
 <p>ong works!</p>
+<p>{{displayOng()}}</p>

--- a/src/app/modules/ong/ong.component.ts
+++ b/src/app/modules/ong/ong.component.ts
@@ -1,4 +1,8 @@
 import { Component, OnInit } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { Ong } from 'src/app/models/ong.model';
+import { OngService } from 'src/app/services/ong.service';
+import { SharedService } from 'src/app/services/shared.service';
 
 @Component({
   selector: 'app-ong',
@@ -7,9 +11,30 @@ import { Component, OnInit } from '@angular/core';
 })
 export class OngComponent implements OnInit {
 
-  constructor() { }
+  ong: Ong;
+  reloadEventsubscription: Subscription;
+
+  constructor(private ongService: OngService,
+              private sharedService: SharedService) {
+    this.reloadEventsubscription =
+      this.sharedService.getReloadEvent().subscribe(() => {
+        this.getOng()
+      })
+  }
 
   ngOnInit(): void {
+    this.getOng()
+  }
+
+  getOng() {
+    let obj = JSON.parse(localStorage.getItem('entitySelected') ?? "Default");
+    this.ongService.getOng(obj ? obj.id.toString() : '0').subscribe(
+      res_ong => { this.ong = res_ong }
+    )
+  }
+
+  displayOng() {
+    return JSON.stringify(this.ong, null, 4)
   }
 
 }

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -19,10 +19,10 @@
           <div class="invalid-feedback" *ngIf="isFailedSearch">Sorry, suggestions could not be loaded.</div>
         </li>
         <li class="nav-item">
-          <a class="nav-link" routerLink="/ong">Nueva Ong</a>
+          <a class="nav-link" routerLink="/ong-form">Nueva Ong</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" routerLink="/campaign">Nueva Campaña</a>
+          <a class="nav-link" routerLink="/campaign-form">Nueva Campaña</a>
         </li>
         <div class="dropdown" *ngIf="tokenService.currentUserData != undefined">
           <button class="btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown"

--- a/src/app/navbar/navbar.component.ts
+++ b/src/app/navbar/navbar.component.ts
@@ -26,11 +26,11 @@ export class NavbarComponent implements OnInit {
   public entitySelected: any;
 
   constructor(public tokenService: AngularTokenService,
-    public ongService: OngService,
-    public campaignService: CampaignService,
-    private sharedService: SharedService,
-    public searchService: SearchService,
-    private router: Router) {
+              public ongService: OngService,
+              public campaignService: CampaignService,
+              private sharedService: SharedService,
+              public searchService: SearchService,
+              private router: Router) {
     this.reloadEventsubscription =
       this.sharedService.getReloadEvent().subscribe(() => {
         this.getOngs();
@@ -84,6 +84,11 @@ export class NavbarComponent implements OnInit {
     this.sharedService.sendReloadEvent()
   }
 
+  reloadPage(entity: any) {
+    localStorage.setItem('entitySelected', JSON.stringify(entity))
+    this.sharedService.sendReloadEvent()
+  }
+
   search = (text$: Observable<string>) =>
     text$.pipe(
       debounceTime(300),
@@ -110,5 +115,6 @@ export class NavbarComponent implements OnInit {
       this.router.navigate(['./campaign']);
     }
     localStorage.setItem('entitySelected', JSON.stringify(event.item))
+    this.reloadPage(event.item)
   }
 }

--- a/src/app/services/campaign.service.ts
+++ b/src/app/services/campaign.service.ts
@@ -21,4 +21,9 @@ export class CampaignService {
     let url = `${this.BASE_URL}/user_campaigns`;
     return this.http.get<Campaign[]>(url);
   }
+
+  getCampaign(id: string): Observable<Campaign> {
+    let url = `${this.BASE_URL}/${id}`;
+    return this.http.get<Campaign>(url);
+  }
 }

--- a/src/app/services/ong.service.ts
+++ b/src/app/services/ong.service.ts
@@ -14,7 +14,7 @@ export class OngService {
   constructor(private http: HttpClient) { }
 
   addOng(ong: Ong): Observable<any> {
-    return this.http.post<Ong>(this.BASE_URL,ong);
+    return this.http.post<Ong>(this.BASE_URL, ong);
   }
 
   getOngs(): Observable<Ong[]> {
@@ -24,5 +24,10 @@ export class OngService {
   myOngs(): Observable<Ong[]> {
     let url = `${this.BASE_URL}/user_ongs`;
     return this.http.get<Ong[]>(url);
+  }
+
+  getOng(id: string): Observable<Ong> {
+    let url = `${this.BASE_URL}/${id}`;
+    return this.http.get<Ong>(url);
   }
 }

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -15,4 +15,9 @@ export class SearchService {
   getEntities(name: string): Observable<any[]> {
     return this.http.get<any[]>(this.BASE_URL + "?q=" + name);
   }
+
+  getInitEntities(): Observable<any[]> {
+    let url = `${this.BASE_URL}/init_entities`;
+    return this.http.get<any[]>(url);
+  }
 }


### PR DESCRIPTION
I displayed ong and campaign entities in their respective components using sibling component communication when selecting different entities from the navbar search results list and I fixed the routes for the new ong and new campaign forms.